### PR TITLE
Feature: Local Multiplayer Support

### DIFF
--- a/Delta/Settings/SettingsViewController.swift
+++ b/Delta/Settings/SettingsViewController.swift
@@ -294,7 +294,7 @@ extension SettingsViewController
         let section = Section(rawValue: sectionIndex)!
         switch section
         {
-        case .controllers: return 1 // Temporarily hide other controller indexes until controller logic is finalized
+        case .controllers: return 4
         case .controllerSkins: return System.registeredSystems.count
         case .syncing: return SyncManager.shared.coordinator?.account == nil ? 1 : super.tableView(tableView, numberOfRowsInSection: sectionIndex)
         default:


### PR DESCRIPTION
This PR (in a series of PRs for Local Multiplayer Support) unlocks the already-implemented multiple controller functionality waiting in Delta so that controllers may be assigned per-player and have correct inputs sent to DeltaCore.

Not opened in any PR is protocol conformance in the GBC, GBA, and melonDS cores. While local multiplayer support does not exist on those cores, they will still need to adopt the protocol, and may simply ignore the new incoming `playerIndex` var.

Other PRs:
- Delta: https://github.com/rileytestut/Delta/pull/128
- DeltaCore: https://github.com/rileytestut/DeltaCore/pull/32
- NES: https://github.com/rileytestut/NESDeltaCore/pull/2
- SNES: https://github.com/rileytestut/SNESDeltaCore/pull/2
- N64: https://github.com/rileytestut/N64DeltaCore/pull/5
- GEN: https://github.com/rileytestut/GPGXDeltaCore/pull/1

Relevant Trello Cards:
- https://trello.com/c/VtDLcykr/71-feature-nes-local-multiplayer
- https://trello.com/c/pwA1ts98/70-feature-snes-local-multiplayer
- https://trello.com/c/Mu9dQ1aZ/72-feature-n64-local-multiplayer