### PR TITLE
Feature: Additional MFi inputs

### DIFF
--- a/Delta/Extensions/Input+Display.swift
+++ b/Delta/Extensions/Input+Display.swift
@@ -128,6 +128,11 @@ extension Input
             case .rightShoulder: return NSLocalizedString("R1", comment: "")
             case .rightTrigger: return NSLocalizedString("R2", comment: "")
             case .rightThumbstickButton: return NSLocalizedString("R3", comment: "")
+            case .psTouchpadButton: return NSLocalizedString("TouchpDelta/Extensions/Input+Display.swiftad", comment: "")
+            case .xboxPaddleButton1: return NSLocalizedString("Paddle1", comment: "")
+            case .xboxPaddleButton2: return NSLocalizedString("Paddle2", comment: "")
+            case .xboxPaddleButton3: return NSLocalizedString("Paddle3", comment: "")
+            case .xboxPaddleButton4: return NSLocalizedString("Paddle4", comment: "")
             }
             
         case .controller(.keyboard):

--- a/Delta/Extensions/Input+Display.swift
+++ b/Delta/Extensions/Input+Display.swift
@@ -104,6 +104,8 @@ extension Input
             switch input
             {
             case .menu: return NSLocalizedString("Menu", comment: "")
+            case .options: return NSLocalizedString("Options", comment: "")
+            case .home: return NSLocalizedString("Home", comment: "")
             case .up: return NSLocalizedString("Up", comment: "")
             case .down: return NSLocalizedString("Down", comment: "")
             case .left: return NSLocalizedString("Left", comment: "")
@@ -122,8 +124,10 @@ extension Input
             case .y: return NSLocalizedString("Y", comment: "")
             case .leftShoulder: return NSLocalizedString("L1", comment: "")
             case .leftTrigger: return NSLocalizedString("L2", comment: "")
+            case .leftThumbstickButton: return NSLocalizedString("L3", comment: "")
             case .rightShoulder: return NSLocalizedString("R1", comment: "")
             case .rightTrigger: return NSLocalizedString("R2", comment: "")
+            case .rightThumbstickButton: return NSLocalizedString("R3", comment: "")
             }
             
         case .controller(.keyboard):

--- a/Delta/Extensions/Input+Display.swift
+++ b/Delta/Extensions/Input+Display.swift
@@ -128,7 +128,7 @@ extension Input
             case .rightShoulder: return NSLocalizedString("R1", comment: "")
             case .rightTrigger: return NSLocalizedString("R2", comment: "")
             case .rightThumbstickButton: return NSLocalizedString("R3", comment: "")
-            case .psTouchpadButton: return NSLocalizedString("TouchpDelta/Extensions/Input+Display.swiftad", comment: "")
+            case .psTouchpadButton: return NSLocalizedString("Touchpad", comment: "")
             case .xboxPaddleButton1: return NSLocalizedString("Paddle1", comment: "")
             case .xboxPaddleButton2: return NSLocalizedString("Paddle2", comment: "")
             case .xboxPaddleButton3: return NSLocalizedString("Paddle3", comment: "")


### PR DESCRIPTION
This PR is a companion PR for a DeltaCore PR (which adds change handlers that listen to some new MFi inputs added since iOS 12. _This_ PR handles the display names for those new inputs.

Corresponding DeltaCore PR: https://github.com/rileytestut/DeltaCore/pull/33

Semi-related Trello card (because the full card is not yet implemented): https://trello.com/c/0DQQD9Zg