### PR TITLE
QOL: Move skin debug setting from each controller skin to a global setting

### DIFF
--- a/Delta/Emulation/GameViewController.swift
+++ b/Delta/Emulation/GameViewController.swift
@@ -281,6 +281,7 @@ extension GameViewController
         self.view.layoutIfNeeded()
         
         self.controllerView.translucentControllerSkinOpacity = Settings.translucentControllerSkinOpacity
+        self.controllerView.isControllerSkinDebugModeEnabled = Settings.isControllerSkinDebugModeEnabled
         
         self.sustainButtonsContentView = UIView(frame: CGRect(x: 0, y: 0, width: self.gameView.bounds.width, height: self.gameView.bounds.height))
         self.sustainButtonsContentView.translatesAutoresizingMaskIntoConstraints = false
@@ -1130,6 +1131,8 @@ private extension GameViewController
         case .translucentControllerSkinOpacity: self.controllerView.translucentControllerSkinOpacity = Settings.translucentControllerSkinOpacity
             
         case .syncingService: break
+            
+        case .isControllerSkinDebugModeEnabled: self.controllerView.isControllerSkinDebugModeEnabled = Settings.isControllerSkinDebugModeEnabled
         }
     }
     

--- a/Delta/Emulation/GameViewController.swift
+++ b/Delta/Emulation/GameViewController.swift
@@ -281,7 +281,7 @@ extension GameViewController
         self.view.layoutIfNeeded()
         
         self.controllerView.translucentControllerSkinOpacity = Settings.translucentControllerSkinOpacity
-        self.controllerView.isControllerSkinDebugModeEnabled = Settings.isControllerSkinDebugModeEnabled
+        self.controllerView.isDebugModeEnabled = Settings.isDebugModeEnabled
         
         self.sustainButtonsContentView = UIView(frame: CGRect(x: 0, y: 0, width: self.gameView.bounds.width, height: self.gameView.bounds.height))
         self.sustainButtonsContentView.translatesAutoresizingMaskIntoConstraints = false
@@ -1132,7 +1132,7 @@ private extension GameViewController
             
         case .syncingService: break
             
-        case .isControllerSkinDebugModeEnabled: self.controllerView.isControllerSkinDebugModeEnabled = Settings.isControllerSkinDebugModeEnabled
+        case .isDebugModeEnabled: self.controllerView.isDebugModeEnabled = Settings.isDebugModeEnabled
         }
     }
     

--- a/Delta/Settings/Settings.swift
+++ b/Delta/Settings/Settings.swift
@@ -38,6 +38,7 @@ extension Settings
         case syncingService
         case isButtonHapticFeedbackEnabled
         case isThumbstickHapticFeedbackEnabled
+        case isControllerSkinDebugModeEnabled
     }
 }
 
@@ -60,6 +61,7 @@ struct Settings
                         #keyPath(UserDefaults.isThumbstickHapticFeedbackEnabled): true,
                         #keyPath(UserDefaults.sortSaveStatesByOldestFirst): true,
                         #keyPath(UserDefaults.isPreviewsEnabled): true,
+                        #keyPath(UserDefaults.isControllerSkinDebugModeEnabled): false,
                         Settings.preferredCoreSettingsKey(for: .ds): MelonDS.core.identifier] as [String : Any]
         UserDefaults.standard.register(defaults: defaults)
     }
@@ -187,6 +189,17 @@ extension Settings
         get {
             let isPreviewsEnabled = UserDefaults.standard.isPreviewsEnabled
             return isPreviewsEnabled
+        }
+    }
+    
+    static var isControllerSkinDebugModeEnabled: Bool {
+        get {
+            let isEnabled = UserDefaults.standard.isControllerSkinDebugModeEnabled
+            return isEnabled
+        }
+        set {
+            UserDefaults.standard.isControllerSkinDebugModeEnabled = newValue
+            NotificationCenter.default.post(name: .settingsDidChange, object: nil, userInfo: [NotificationUserInfoKey.name: Name.isControllerSkinDebugModeEnabled])
         }
     }
     
@@ -385,4 +398,6 @@ private extension UserDefaults
     @NSManaged var sortSaveStatesByOldestFirst: Bool
     
     @NSManaged var isPreviewsEnabled: Bool
+    
+    @NSManaged var isControllerSkinDebugModeEnabled: Bool
 }

--- a/Delta/Settings/Settings.swift
+++ b/Delta/Settings/Settings.swift
@@ -38,7 +38,7 @@ extension Settings
         case syncingService
         case isButtonHapticFeedbackEnabled
         case isThumbstickHapticFeedbackEnabled
-        case isControllerSkinDebugModeEnabled
+        case isDebugModeEnabled
     }
 }
 
@@ -61,7 +61,7 @@ struct Settings
                         #keyPath(UserDefaults.isThumbstickHapticFeedbackEnabled): true,
                         #keyPath(UserDefaults.sortSaveStatesByOldestFirst): true,
                         #keyPath(UserDefaults.isPreviewsEnabled): true,
-                        #keyPath(UserDefaults.isControllerSkinDebugModeEnabled): false,
+                        #keyPath(UserDefaults.isDebugModeEnabled): false,
                         Settings.preferredCoreSettingsKey(for: .ds): MelonDS.core.identifier] as [String : Any]
         UserDefaults.standard.register(defaults: defaults)
     }
@@ -192,14 +192,14 @@ extension Settings
         }
     }
     
-    static var isControllerSkinDebugModeEnabled: Bool {
+    static var isDebugModeEnabled: Bool {
         get {
-            let isEnabled = UserDefaults.standard.isControllerSkinDebugModeEnabled
+            let isEnabled = UserDefaults.standard.isDebugModeEnabled
             return isEnabled
         }
         set {
-            UserDefaults.standard.isControllerSkinDebugModeEnabled = newValue
-            NotificationCenter.default.post(name: .settingsDidChange, object: nil, userInfo: [NotificationUserInfoKey.name: Name.isControllerSkinDebugModeEnabled])
+            UserDefaults.standard.isDebugModeEnabled = newValue
+            NotificationCenter.default.post(name: .settingsDidChange, object: nil, userInfo: [NotificationUserInfoKey.name: Name.isDebugModeEnabled])
         }
     }
     
@@ -399,5 +399,5 @@ private extension UserDefaults
     
     @NSManaged var isPreviewsEnabled: Bool
     
-    @NSManaged var isControllerSkinDebugModeEnabled: Bool
+    @NSManaged var isDebugModeEnabled: Bool
 }

--- a/Delta/Settings/SettingsViewController.swift
+++ b/Delta/Settings/SettingsViewController.swift
@@ -99,6 +99,12 @@ class SettingsViewController: UITableViewController
             self.versionLabel.text = NSLocalizedString("Delta", comment: "")
             #endif
         }
+        
+        let tapGesture = UITapGestureRecognizer(target: self, action: #selector(SettingsViewController.handleTapGesture(_:)))
+        tapGesture.numberOfTapsRequired = 13
+        tapGesture.numberOfTouchesRequired = 1
+        self.versionLabel.addGestureRecognizer(tapGesture)
+        self.versionLabel.isUserInteractionEnabled = true
     }
     
     override func viewWillAppear(_ animated: Bool)
@@ -150,6 +156,15 @@ class SettingsViewController: UITableViewController
             
         case Segue.dsSettings: break
         }
+    }
+    
+    @objc func handleTapGesture(_ gestureRecognizer: UILongPressGestureRecognizer) {
+        let skinDebugEnabled = !Settings.isControllerSkinDebugModeEnabled
+        Settings.isControllerSkinDebugModeEnabled = skinDebugEnabled
+        
+        let alertController = UIAlertController(title: NSLocalizedString("Controller Skin Debug Mode Updated", comment: ""), message: NSLocalizedString("Controller Skin Debug Mode has been changed to \(skinDebugEnabled ? "ON" : "OFF")", comment: ""), preferredStyle: .alert)
+        alertController.addAction(.ok)
+        self.present(alertController, animated: true, completion: nil)
     }
 }
 
@@ -290,7 +305,7 @@ private extension SettingsViewController
                 self.tableView.selectRow(at: selectedIndexPath, animated: true, scrollPosition: .none)
             }
             
-        case .localControllerPlayerIndex, .preferredControllerSkin, .translucentControllerSkinOpacity, .isButtonHapticFeedbackEnabled, .isThumbstickHapticFeedbackEnabled: break
+        case .localControllerPlayerIndex, .preferredControllerSkin, .translucentControllerSkinOpacity, .isButtonHapticFeedbackEnabled, .isThumbstickHapticFeedbackEnabled, .isControllerSkinDebugModeEnabled: break
         }
     }
 

--- a/Delta/Settings/SettingsViewController.swift
+++ b/Delta/Settings/SettingsViewController.swift
@@ -100,8 +100,8 @@ class SettingsViewController: UITableViewController
             #endif
         }
         
-        let tapGesture = UITapGestureRecognizer(target: self, action: #selector(SettingsViewController.handleTapGesture(_:)))
-        tapGesture.numberOfTapsRequired = 13
+        let tapGesture = UITapGestureRecognizer(target: self, action: #selector(SettingsViewController.handleVersionLabelTapGesture(_:)))
+        tapGesture.numberOfTapsRequired = 3
         tapGesture.numberOfTouchesRequired = 1
         self.versionLabel.addGestureRecognizer(tapGesture)
         self.versionLabel.isUserInteractionEnabled = true
@@ -158,11 +158,11 @@ class SettingsViewController: UITableViewController
         }
     }
     
-    @objc func handleTapGesture(_ gestureRecognizer: UILongPressGestureRecognizer) {
+    @objc func handleVersionLabelTapGesture(_ gestureRecognizer: UILongPressGestureRecognizer) {
         let skinDebugEnabled = !Settings.isDebugModeEnabled
         Settings.isDebugModeEnabled = skinDebugEnabled
         
-        let alertController = UIAlertController(title: NSLocalizedString("Controller Skin Debug Mode Updated", comment: ""), message: NSLocalizedString("Controller Skin Debug Mode has been changed to \(skinDebugEnabled ? "ON" : "OFF")", comment: ""), preferredStyle: .alert)
+        let alertController = UIAlertController(title: NSLocalizedString("Debug Mode Updated", comment: ""), message: NSLocalizedString("Debug Mode is now \(skinDebugEnabled ? "ON" : "OFF")", comment: ""), preferredStyle: .alert)
         alertController.addAction(.ok)
         self.present(alertController, animated: true, completion: nil)
     }

--- a/Delta/Settings/SettingsViewController.swift
+++ b/Delta/Settings/SettingsViewController.swift
@@ -159,8 +159,8 @@ class SettingsViewController: UITableViewController
     }
     
     @objc func handleTapGesture(_ gestureRecognizer: UILongPressGestureRecognizer) {
-        let skinDebugEnabled = !Settings.isControllerSkinDebugModeEnabled
-        Settings.isControllerSkinDebugModeEnabled = skinDebugEnabled
+        let skinDebugEnabled = !Settings.isDebugModeEnabled
+        Settings.isDebugModeEnabled = skinDebugEnabled
         
         let alertController = UIAlertController(title: NSLocalizedString("Controller Skin Debug Mode Updated", comment: ""), message: NSLocalizedString("Controller Skin Debug Mode has been changed to \(skinDebugEnabled ? "ON" : "OFF")", comment: ""), preferredStyle: .alert)
         alertController.addAction(.ok)
@@ -305,7 +305,7 @@ private extension SettingsViewController
                 self.tableView.selectRow(at: selectedIndexPath, animated: true, scrollPosition: .none)
             }
             
-        case .localControllerPlayerIndex, .preferredControllerSkin, .translucentControllerSkinOpacity, .isButtonHapticFeedbackEnabled, .isThumbstickHapticFeedbackEnabled, .isControllerSkinDebugModeEnabled: break
+        case .localControllerPlayerIndex, .preferredControllerSkin, .translucentControllerSkinOpacity, .isButtonHapticFeedbackEnabled, .isThumbstickHapticFeedbackEnabled, .isDebugModeEnabled: break
         }
     }
 


### PR DESCRIPTION
This is mainly for ease of use in testing out new Controller Skins, as well as efforts in updating the skin spec.

DeltaCore PR: https://github.com/rileytestut/DeltaCore/pull/34

Trello Card: https://trello.com/c/IGSv3tcf