### PR TITLE
Feature: adds FF Toggle as an option for Controller Mappings

### DIFF
--- a/Delta/Settings/Controllers/ControllerInputsViewController.swift
+++ b/Delta/Settings/Controllers/ControllerInputsViewController.swift
@@ -31,7 +31,7 @@ class ControllerInputsViewController: UIViewController
     private lazy var managedObjectContext: NSManagedObjectContext = DatabaseManager.shared.newBackgroundContext()
     private var inputMappings = [System: GameControllerInputMapping]()
     
-    private let supportedActionInputs: [ActionInput] = [.quickSave, .quickLoad, .fastForward]
+    private let supportedActionInputs: [ActionInput] = [.quickSave, .quickLoad, .fastForward, .toggleFastForward]
     
     private var gameViewController: DeltaCore.GameViewController!
     private var actionsMenuViewController: GridMenuViewController!
@@ -224,7 +224,9 @@ private extension ControllerInputsViewController
                 image = #imageLiteral(resourceName: "FastForward")
                 text = NSLocalizedString("Fast Forward", comment: "")
                 
-            case .toggleFastForward: continue
+            case .toggleFastForward:
+                image = #imageLiteral(resourceName: "FastForward")
+                text = NSLocalizedString("Toggle FF", comment: "")
             }
             
             let item = MenuItem(text: text, image: image) { [unowned self] (item) in


### PR DESCRIPTION
I saw a request for adding the FF Toggle to the Controller Mappings screen, so I figured I'd open this.

It's not perfect by any means; having 4 item on this screen's `GridMenuViewController` adds two rows, which isn't ideal and makes it a bit harder to configure those Actions since they're so close together.

But still, here it is in case anyone wants it.