### PR TITLE
Feature: lock GameViewController from rotating if an External Game Controller is connected

### DIFF
--- a/Delta/Emulation/GameViewController.swift
+++ b/Delta/Emulation/GameViewController.swift
@@ -168,7 +168,11 @@ class GameViewController: DeltaCore.GameViewController
     private var presentedGyroAlert = false
     
     override var shouldAutorotate: Bool {
-        return !self.isGyroActive
+        return !self.isGyroActive && !isExternalGameControllerConnected
+    }
+    
+    var isExternalGameControllerConnected: Bool {
+        return ExternalGameControllerManager.shared.connectedControllers.contains(where: { $0.playerIndex != nil })
     }
     
     override var preferredScreenEdgesDeferringSystemGestures: UIRectEdge {
@@ -546,7 +550,6 @@ private extension GameViewController
 {
     @objc func updateControllers()
     {
-        let isExternalGameControllerConnected = ExternalGameControllerManager.shared.connectedControllers.contains(where: { $0.playerIndex != nil })
         if !isExternalGameControllerConnected && Settings.localControllerPlayerIndex == nil
         {
             Settings.localControllerPlayerIndex = 0


### PR DESCRIPTION
This is lighter attempt at solving https://trello.com/c/bO57L3PN, which asks to lock the screen orientation to a fixed position when the Backbone (or Razer Kishi) is connected, since they have a fixed orientation.

It's a simple idea in practice, but iOS unfortunately does not give us an easy way to do this _dynamically_. You can override the supportedInterfaceOrientations per-controller, but I'm not finding a way for that to be conditional; you override the var and are done with it. Likely I could use a local variable, monitor the device's orientation and set the local var, but to do that for every controller (or to subclass every controller) is likely more trouble than it's worth.

In light of that, this change gets you _most_ of the way there (for the GameViewController at least), and is significantly less effort.