### PR TITLE
removed call of setitems which caused a crash

### DIFF
--- a/Delta/Settings/App Icon Shortcuts/AppIconShortcutsViewController.swift
+++ b/Delta/Settings/App Icon Shortcuts/AppIconShortcutsViewController.swift
@@ -178,8 +178,7 @@ private extension AppIconShortcutsViewController
             
             do
             {
-                let games = try DatabaseManager.shared.viewContext.fetch(fetchRequest)
-                self.shortcutsDataSource.setItems(games, with: [])
+                let _ = try DatabaseManager.shared.viewContext.fetch(fetchRequest)
             }
             catch
             {


### PR DESCRIPTION
Mark the type contribution you are making:

- [ ] Experimental feature (new functionality that can be selectively enabled/disabled)
- [X] Bug fix (non-breaking change which fixes an issue)

# Description

Summary of your changes, including: 

* Why is this change necessary?
* Why did you decide on this solution?


The app would automatically crash when a shortcut was removed from recently played. I removed the setItems call because it caused inconsistencies with the NSArray.

# Testing

-iPhone 12 Pro 17.4.1
-iPhone 11 Pro 17.1.2

# Checklist
**General (All PRs)**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [N/A] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I've tested my changes with different device + OS version configurations

**Experimental Feature-specific** 
- [ ] Added property to `ExperimentalFeatures` struct annotated with `@Feature`
- [ ] Uses `@Option`'s to persist all feature-related data
- [ ] Locked *all* behavior changes behind `ExperimentalFeatures.shared.[feature].isEnabled` runtime check
- [ ] Isolates changes to separate files as much as possible (e.g. via Swift extensions)
