### PR TITLE
Add quick save stack experimental feature.

### DIFF
--- a/Delta.xcodeproj/project.pbxproj
+++ b/Delta.xcodeproj/project.pbxproj
@@ -253,6 +253,7 @@
 		D5EB601B2C0E6190007C543C /* Stream+Conveniences.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5EB601A2C0E6190007C543C /* Stream+Conveniences.swift */; };
 		D5F702FD2C24CE5300DCD271 /* UISceneSession+Delta.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5F702FC2C24CE5300DCD271 /* UISceneSession+Delta.swift */; };
 		D5F82FB82981D3AC00B229AF /* LegacySearchBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5F82FB72981D3AC00B229AF /* LegacySearchBar.swift */; };
+		DC1486CE2C604B130001E81C /* QuickSaveStackOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC1486CD2C604B130001E81C /* QuickSaveStackOptions.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -546,6 +547,7 @@
 		D5EB601A2C0E6190007C543C /* Stream+Conveniences.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Stream+Conveniences.swift"; sourceTree = "<group>"; };
 		D5F702FC2C24CE5300DCD271 /* UISceneSession+Delta.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UISceneSession+Delta.swift"; sourceTree = "<group>"; };
 		D5F82FB72981D3AC00B229AF /* LegacySearchBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LegacySearchBar.swift; sourceTree = "<group>"; };
+		DC1486CD2C604B130001E81C /* QuickSaveStackOptions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuickSaveStackOptions.swift; sourceTree = "<group>"; };
 		DC866E433B3BA9AE18ABA1EC /* libPods-Delta.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Delta.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
@@ -1193,6 +1195,8 @@
 				AC1C990F29F8B8C30020E6E4 /* ToastNotificationOptions.swift */,
 				D5147EC72A817B4A00D6CD64 /* ReviewSaveStatesOptions.swift */,
 				D5A287242C23A1AC009883C3 /* SkinDebugging.swift */,
+				AC1AE3092A69BD3A00956EB9 /* AlternateAppIcons.swift */,
+				DC1486CD2C604B130001E81C /* QuickSaveStackOptions.swift */,
 			);
 			path = Features;
 			sourceTree = "<group>";
@@ -1695,6 +1699,7 @@
 				BF34FA111CF1899D006624C7 /* CheatTextView.swift in Sources */,
 				D524F4A5273DEBB400D500B2 /* ServerManager+Delta.swift in Sources */,
 				D5AAF27729884F8600F21ACF /* CheatDevice.swift in Sources */,
+				DC1486CE2C604B130001E81C /* QuickSaveStackOptions.swift in Sources */,
 				BF1F45AD21AF57BA00EF9895 /* HarmonyMetadataKey+Keys.swift in Sources */,
 				BFD1EF402336BD8800D197CF /* UIDevice+Processor.swift in Sources */,
 				BF71CF871FE90006001F1613 /* AppIconShortcutsViewController.swift in Sources */,

--- a/Delta/Experimental Features/ExperimentalFeatures.swift
+++ b/Delta/Experimental Features/ExperimentalFeatures.swift
@@ -57,6 +57,11 @@ struct ExperimentalFeatures: FeatureContainer
              description: "Visually show touches. Useful for screen recordings and tutorials.")
     var showTouches
     
+    @Feature(name: "Quick Save Stack",
+             description: "Maintain multiple quick saves in a stack.",
+             options: QuickSaveStatesOptions())
+    var quickSaveStack
+
     private init()
     {
         self.prepareFeatures()

--- a/Delta/Experimental Features/Features/QuickSaveStackOptions.swift
+++ b/Delta/Experimental Features/Features/QuickSaveStackOptions.swift
@@ -1,0 +1,25 @@
+//
+//  QuickSaveStackOptions.swift
+//  Delta
+//
+//  Created by Cooper Knaak on 8/4/24.
+//  Copyright © 2024 Riley Testut. All rights reserved.
+//
+
+import Foundation
+
+import DeltaFeatures
+
+struct QuickSaveStatesOptions
+{
+    enum Size: Int, CaseIterable, CustomStringConvertible, OptionValue, LocalizedOptionValue {
+        case two = 2
+        case four = 4
+        case eight = 8
+
+        var description: String { return "\(self.rawValue)" }
+    }
+
+    @Option(name: "Stack Size", values: Size.allCases)
+    var size = Size.two
+}


### PR DESCRIPTION
Mark the type contribution you are making:

- [x ] Experimental feature (new functionality that can be selectively enabled/disabled)
- [ ] Bug fix (non-breaking change which fixes an issue)

# Description

Add an experimental feature that lets you have multiple quick save states at once, up to a user-configurable limit. Creating a new quick save when already at the limit removes the oldest quick save (the first in the collection view).

In my experience using Delta, I want to create speculative save states a lot. But opening the menu, selecting save states, creating a save state, then returning to the game, takes a long time. In particular, playing Pokemon RomHacks, I want to create a save state before the battle. But in the middle of the battle, it's often convenient to create another save state, such as when using a risky move (don't judge me). Creating a quick save is extremely fast, but it would overwrite my save from before the battle. Quick save stacks change that.

# Testing

- iPhone 15 Pro, iOS 18.0
- iPhone X, iOS 15.7.4

# Checklist
**General (All PRs)**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I've tested my changes with different device + OS version configurations

**Experimental Feature-specific** 
- [x] Added property to `ExperimentalFeatures` struct annotated with `@Feature`
- [x] Uses `@Option`'s to persist all feature-related data
- [x] Locked *all* behavior changes behind `ExperimentalFeatures.shared.[feature].isEnabled` runtime check
- [x] Isolates changes to separate files as much as possible (e.g. via Swift extensions) **I added a new method to `SettingsViewController`**. Riley, let me know if you'd prefer this in its own file. I couldn't think of a more logical hook without creating a dedicated singleton.
