### PR TITLE
Operator integration hardening

### DIFF
--- a/Delta.xcodeproj/project.pbxproj
+++ b/Delta.xcodeproj/project.pbxproj
@@ -40,6 +40,10 @@
 		4F501EDE15C52E1E6230DB9E /* DeltaOperatorGameObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4327597BCB33E196164D3BB6 /* DeltaOperatorGameObserver.swift */; };
 		5FFDBC83E8777EB11777803A /* GamesViewController+Operator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B6FDC5A03AD5693BEFFE87C /* GamesViewController+Operator.swift */; };
 		6FF8B1728BDBAF892B397F5E /* DeltaOperatorWritebackToast.swift in Sources */ = {isa = PBXBuildFile; fileRef = FCE7674E5643CDB43BC8ED32 /* DeltaOperatorWritebackToast.swift */; };
+		DE17A0A57E000000000000B2 /* DeltaOperatorToast.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE17A0A57E000000000000A1 /* DeltaOperatorToast.swift */; };
+		DE17A0A57E00000000000202 /* DeltaOperatorSaveReadToast.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE17A0A57E00000000000201 /* DeltaOperatorSaveReadToast.swift */; };
+		DE17A0A57E00000000000302 /* OperatorLaunchCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE17A0A57E00000000000301 /* OperatorLaunchCoordinator.swift */; };
+		DE17A0A57E000000000000F2 /* DeltaOperatorImportToast.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE17A0A57E000000000000E1 /* DeltaOperatorImportToast.swift */; };
 		70FF20879DA0DCEE53D8CAED /* OperatorKit.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 796FA895EF62DF6A509DCA55 /* OperatorKit.xcframework */; };
 		823D998F2E566EE40025F4CD /* GBCColorPalette.swift in Sources */ = {isa = PBXBuildFile; fileRef = 823D998E2E566EE40025F4CD /* GBCColorPalette.swift */; };
 		8279ED042E53BA4F008995FA /* GBACoreSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8279ED032E53BA4F008995FA /* GBACoreSettingsView.swift */; };
@@ -938,6 +942,10 @@
 		E6BD34AC2F587BF0001C9D78 /* AchievementGameBanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AchievementGameBanner.swift; sourceTree = "<group>"; };
 		E6EB10AE2F58B1C50001AAD2 /* AchievementNotification.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AchievementNotification.swift; sourceTree = "<group>"; };
 		FCE7674E5643CDB43BC8ED32 /* DeltaOperatorWritebackToast.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeltaOperatorWritebackToast.swift; sourceTree = "<group>"; };
+		DE17A0A57E000000000000A1 /* DeltaOperatorToast.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeltaOperatorToast.swift; sourceTree = "<group>"; };
+		DE17A0A57E00000000000201 /* DeltaOperatorSaveReadToast.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeltaOperatorSaveReadToast.swift; sourceTree = "<group>"; };
+		DE17A0A57E00000000000301 /* OperatorLaunchCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OperatorLaunchCoordinator.swift; sourceTree = "<group>"; };
+		DE17A0A57E000000000000E1 /* DeltaOperatorImportToast.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeltaOperatorImportToast.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -998,7 +1006,11 @@
 				4327597BCB33E196164D3BB6 /* DeltaOperatorGameObserver.swift */,
 				DCBF2F877CA6072880A54F35 /* DeltaOperatorUtils.swift */,
 				FCE7674E5643CDB43BC8ED32 /* DeltaOperatorWritebackToast.swift */,
+				DE17A0A57E000000000000A1 /* DeltaOperatorToast.swift */,
+				DE17A0A57E000000000000E1 /* DeltaOperatorImportToast.swift */,
+				DE17A0A57E00000000000201 /* DeltaOperatorSaveReadToast.swift */,
 				0654CFCA3D2CB4D35CC99F89 /* OperatorSlotDataSource.swift */,
+				DE17A0A57E00000000000301 /* OperatorLaunchCoordinator.swift */,
 				7C31F852121CBEF08181BD23 /* OperatorStatusView.swift */,
 				C1C8C13CE90324CBBA76BC3E /* OperatorUICoordinators.swift */,
 			);
@@ -2698,6 +2710,10 @@
 				B8BF6056C00AB0507A06D39E /* OperatorStatusView.swift in Sources */,
 				28B653353E8323FA65C54A42 /* OperatorUICoordinators.swift in Sources */,
 				6FF8B1728BDBAF892B397F5E /* DeltaOperatorWritebackToast.swift in Sources */,
+				DE17A0A57E000000000000B2 /* DeltaOperatorToast.swift in Sources */,
+				DE17A0A57E000000000000F2 /* DeltaOperatorImportToast.swift in Sources */,
+				DE17A0A57E00000000000202 /* DeltaOperatorSaveReadToast.swift in Sources */,
+				DE17A0A57E00000000000302 /* OperatorLaunchCoordinator.swift in Sources */,
 				18FC614F90FE76140AAECE67 /* DeltaOperatorUtils.swift in Sources */,
 				89DAEB1EDE294B3A7C857765 /* DeltaOperatorFacade.swift in Sources */,
 				CA0001192E60000100000019 /* CoresListView.swift in Sources */,

--- a/Delta/Extensions/AppDelegate+Operator.swift
+++ b/Delta/Extensions/AppDelegate+Operator.swift
@@ -26,7 +26,9 @@ extension AppDelegate
     func handleOperatorDatabaseReady()
     {
         guard ExperimentalFeatures.shared.operatorDevice.isEnabled else { return }
-        self.operatorFacade.onDatabaseReady()
+        DispatchQueue.main.async {
+            self.operatorFacade.onDatabaseReady()
+        }
     }
 }
 

--- a/Delta/Extensions/GameCollectionViewController+Operator.swift
+++ b/Delta/Extensions/GameCollectionViewController+Operator.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2026 Epilogue. All rights reserved.
 //
 
+import Combine
 import UIKit
 import ObjectiveC.runtime
 
@@ -13,6 +14,9 @@ import DeltaFeatures
 import OperatorKit
 
 private var operatorCoordinatorKey: UInt8 = 0
+private var operatorLaunchCoordinatorKey: UInt8 = 0
+private var pendingLaunchGameKey: UInt8 = 0
+private var slotStateCancellableKey: UInt8 = 0
 
 extension GameCollectionViewController
 {
@@ -58,6 +62,30 @@ extension GameCollectionViewController
     {
         return OperatorKitController.shared.importedGameIdentifier == game.identifier
     }
+
+    func isOperatorImportInProgress(for game: Game) -> Bool
+    {
+        let controller = OperatorKitController.shared
+        guard controller.importedGameIdentifier == game.identifier else { return false }
+        if case .imported = controller.slotState { return false }
+        return true
+    }
+
+    func deferLaunchIfOperatorImporting(_ game: Game) -> Bool
+    {
+        guard ExperimentalFeatures.shared.operatorDevice.isEnabled else { return false }
+
+        if self.isOperatorImportInProgress(for: game)
+        {
+            self.pendingOperatorLaunchGame = game
+            self.startOperatorLaunchObserver()
+            return true
+        }
+        self.pendingOperatorLaunchGame = nil
+
+        guard self.isOperatorImportedGame(game) else { return false }
+        return self.operatorLaunchCoordinator.deferLaunchIfSaveUnverified(of: game)
+    }
 }
 
 private extension GameCollectionViewController
@@ -72,6 +100,53 @@ private extension GameCollectionViewController
             let coordinator = OperatorCollectionCoordinator()
             objc_setAssociatedObject(self, &operatorCoordinatorKey, coordinator, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
             return coordinator
+        }
+    }
+
+    var pendingOperatorLaunchGame: Game? {
+        get { objc_getAssociatedObject(self, &pendingLaunchGameKey) as? Game }
+        set { objc_setAssociatedObject(self, &pendingLaunchGameKey, newValue, .OBJC_ASSOCIATION_RETAIN_NONATOMIC) }
+    }
+
+    var operatorLaunchCancellable: AnyCancellable? {
+        get { objc_getAssociatedObject(self, &slotStateCancellableKey) as? AnyCancellable }
+        set { objc_setAssociatedObject(self, &slotStateCancellableKey, newValue, .OBJC_ASSOCIATION_RETAIN_NONATOMIC) }
+    }
+
+    var operatorLaunchCoordinator: OperatorLaunchCoordinator {
+        get {
+            if let coordinator = objc_getAssociatedObject(self, &operatorLaunchCoordinatorKey) as? OperatorLaunchCoordinator
+            {
+                return coordinator
+            }
+
+            let coordinator = OperatorLaunchCoordinator()
+            coordinator.start(collectionViewController: self)
+            objc_setAssociatedObject(self, &operatorLaunchCoordinatorKey, coordinator, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
+            return coordinator
+        }
+    }
+
+    func startOperatorLaunchObserver()
+    {
+        guard self.operatorLaunchCancellable == nil else { return }
+        self.operatorLaunchCancellable = OperatorKitController.shared.$slotState
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] state in self?.launchPendingOperatorGameIfReady(state) }
+    }
+
+    func launchPendingOperatorGameIfReady(_ state: OperatorSlotState)
+    {
+        guard case .imported(let id) = state,
+              let game = self.pendingOperatorLaunchGame, game.identifier == id
+        else { return }
+        self.pendingOperatorLaunchGame = nil
+
+        DispatchQueue.main.async { [weak self] in
+            guard let self, let collectionView = self.collectionView,
+                  let indexPath = self.dataSource.fetchedResultsController.indexPath(forObject: game)
+            else { return }
+            self.collectionView(collectionView, didSelectItemAt: indexPath)
         }
     }
 }

--- a/Delta/Extensions/GamesViewController+Operator.swift
+++ b/Delta/Extensions/GamesViewController+Operator.swift
@@ -6,12 +6,17 @@
 //  Copyright © 2026 Epilogue. All rights reserved.
 //
 
+import Combine
+import CoreData
 import UIKit
 import ObjectiveC.runtime
 
+import DeltaCore
 import DeltaFeatures
+import OperatorKit
 
 private var operatorOverlayKey: UInt8 = 0
+private var operatorSlotObserverKey: UInt8 = 0
 
 extension GamesViewController
 {
@@ -25,13 +30,21 @@ extension GamesViewController
     func configureOperatorOverlay(placeholderStackView: UIStackView)
     {
         guard ExperimentalFeatures.shared.operatorDevice.isEnabled else { return }
+        self.startOperatorImportObserver()
         self.operatorOverlay.install(in: self.view, placeholderStackView: placeholderStackView)
     }
 
-    func updateOperatorPlaceholderVisibility(sectionCount: Int)
+    func updateOperatorPlaceholderVisibility(sectionCount: Int, isLibraryHidden: Bool)
     {
         guard ExperimentalFeatures.shared.operatorDevice.isEnabled else { return }
-        self.operatorOverlay.isPlaceholderVisible = (sectionCount == 0)
+        self.operatorOverlay.isPlaceholderVisible = (sectionCount == 0) || (self.isOperatorImportTransferring && isLibraryHidden)
+    }
+
+    var isOperatorImportTransferring: Bool
+    {
+        guard ExperimentalFeatures.shared.operatorDevice.isEnabled else { return false }
+        if case .transferring = OperatorKitController.shared.slotState { return true }
+        return false
     }
 }
 
@@ -47,6 +60,59 @@ private extension GamesViewController
             let overlay = OperatorOverlayCoordinator()
             objc_setAssociatedObject(self, &operatorOverlayKey, overlay, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
             return overlay
+        }
+    }
+
+    var operatorSlotCancellable: AnyCancellable? {
+        get { objc_getAssociatedObject(self, &operatorSlotObserverKey) as? AnyCancellable }
+        set { objc_setAssociatedObject(self, &operatorSlotObserverKey, newValue, .OBJC_ASSOCIATION_RETAIN_NONATOMIC) }
+    }
+
+    func startOperatorImportObserver()
+    {
+        guard self.operatorSlotCancellable == nil else { return }
+        self.operatorSlotCancellable = OperatorKitController.shared.$slotState
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] state in
+                guard case .imported = state else { return }
+                self?.updateSections(animated: false)
+                self?.switchToImportedOperatorCollection()
+            }
+    }
+
+    func switchToImportedOperatorCollection()
+    {
+        guard let signature = OperatorKitController.shared.publishedSignature, !signature.isEmpty,
+              let identifier = GameType(fileExtension: signature.romExtension)?.rawValue,
+              let pageViewController = self.children.first(where: { $0 is UIPageViewController }) as? UIPageViewController
+        else { return }
+
+        let currentViewController = pageViewController.viewControllers?.first as? GameCollectionViewController
+        guard currentViewController?.gameCollection?.identifier != identifier else { return }
+
+        let fetchRequest = GameCollection.fetchRequest() as NSFetchRequest<GameCollection>
+        let collectionCount = (try? DatabaseManager.shared.viewContext.count(for: fetchRequest)) ?? 0
+
+        var target: (index: Int, viewController: GameCollectionViewController)?
+        for index in 0..<(collectionCount + 2)
+        {
+            guard let viewController = self.viewControllerForIndex(index) else { break }
+            guard viewController.gameCollection?.identifier == identifier else { continue }
+            target = (index, viewController)
+            break
+        }
+        guard let target else { return }
+
+        let currentIndex = currentViewController.flatMap { self.indexForViewController($0) } ?? 0
+        let direction: UIPageViewController.NavigationDirection = target.index > currentIndex ? .forward : .reverse
+
+        pageViewController.setViewControllers([target.viewController], direction: direction, animated: true) { [weak self] _ in
+            self?.updateSections(animated: false)
+        }
+        self.title = target.viewController.title
+        if let collection = target.viewController.gameCollection
+        {
+            Settings.previousGameCollection = collection
         }
     }
 }

--- a/Delta/Game Selection/GameCollectionViewController.swift
+++ b/Delta/Game Selection/GameCollectionViewController.swift
@@ -1393,6 +1393,7 @@ extension GameCollectionViewController
         // Operator: ignore taps on device status cell
         guard !self.isOperatorSlotIndexPath(indexPath) else { return }
         guard self.gameCollection?.identifier != GameType.unknown.rawValue else { return }
+        guard !self.deferLaunchIfOperatorImporting(self.dataSource.item(at: indexPath)) else { return }
 
         // Check for iOS 26, setting toggled on, and stage manager enabled, then open game in new window
         if #available(iOS 26, *),

--- a/Delta/Game Selection/GamesViewController.swift
+++ b/Delta/Game Selection/GamesViewController.swift
@@ -400,7 +400,7 @@ private extension GamesViewController
 }
 
 // MARK: - Helper Methods -
-private extension GamesViewController
+internal extension GamesViewController
 {
     func viewControllerForIndex(_ index: Int) -> GameCollectionViewController?
     {
@@ -476,12 +476,12 @@ private extension GamesViewController
         self.pageControl.setHidden(sections < 2, animated: false)
         
         // Operator: show or hide cartridge status on empty placeholder
-        self.updateOperatorPlaceholderVisibility(sectionCount: sections)
+        self.updateOperatorPlaceholderVisibility(sectionCount: sections, isLibraryHidden: self.pageViewController.view.isHidden)
 
         if sections > 0
         {
             // Reset page view controller if currently hidden or current child should view controller no longer exists
-            if self.pageViewController.view.isHidden || resetPageViewController
+            if (self.pageViewController.view.isHidden || resetPageViewController), !self.isOperatorImportTransferring
             {
                 let index = min(1, self.pages.count - 1) // Recents page, or first game system
                 
@@ -497,7 +497,7 @@ private extension GamesViewController
                     self.pageControl.model.currentPage = index
                 }
             }
-            else
+            else if !self.isOperatorImportTransferring
             {
                 self.pageViewController.setViewControllers(self.pageViewController.viewControllers, direction: .forward, animated: false, completion: nil)
             }


### PR DESCRIPTION
Mark the type contribution you are making:

- [ ] Experimental feature (new functionality that can be selectively enabled/disabled)
- [x] Bug fix (non-breaking change which fixes an issue)

# Description

This is a hardening pass on the existing **Epilogue Operator** experimental feature. It fixes data-loss and UI edge cases surfaced during on-device testing, plus improves cartridge detection.

**What this PR changes:**

- **Save reliability / data integrity**: hardens cartridge save handling against data loss (writeback guards), and restores game dismissal when its cartridge is re-inserted.
- **Launch gating on a verified save**: a game launched from a cartridge now waits for its save to be verified, recovers a failed read, and prompts the user before ever starting without save data.
- **Cartridge detection**: more reliable detection of cartridge removal and SNES carts, so a removed cartridge no longer reads as still inserted.
- **Import UX**: clearer progress feedback and toasts during cartridge import, and fixes to library/overlay glitches while importing.

**Why is this change necessary?**
On-device testing of the shipped Operator feature exposed several ways a cartridge session could lose save data or leave the library UI in a wrong/flashing state (e.g. an interrupted save write, a removed cartridge still reading as inserted, launching before the save was read).

**Why did you decide on this solution?**
- Kept all changes behind the existing `operatorDevice` flag and inside the isolated `+Operator` Swift extensions / `DeltaOperator` + `OperatorKit` layer, so upstream Delta code paths are barely touched.
- Chose to gate launch on a verified save (with recovery + user prompt) rather than launch optimistically, since silently starting without save data risks overwriting the cartridge.
- Reworked cartridge-presence detection so a removed cartridge is recognized promptly instead of lingering as "inserted".

# Testing

Tested on the following, all running the latest iOS release:

- iPhone 16
- iPhone 16 Pro Max
- iPhone 17 Pro

# Checklist
**General (All PRs)**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I've tested my changes with different device + OS version configurations

**Experimental Feature-specific**
- [ ] Added property to `ExperimentalFeatures` struct annotated with `@Feature`
- [ ] Uses `@Option`'s to persist all feature-related data
- [x] Locked *all* behavior changes behind `ExperimentalFeatures.shared.[feature].isEnabled` runtime check
- [x] Isolates changes to separate files as much as possible (e.g. via Swift extensions)
